### PR TITLE
string option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stattotex
 
-Forked versions of Ian Sappolnik's great `stattotex` command with added `string` option.
+Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option.
 
 A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ A Stata command to automatically place a calculation into LaTeX -- no more hard 
 
 See the PDF and do file for more details.
 
+You can install the latest version of the *FORKED* command by executing the following code:
+`net install stattotex, from("https://raw.github.com/cg89x/stattotex/master/") replace`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stattotex
 
-Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option to export strings as well. Note that hyphenation of longer strings provided by the `babel` package using USenglish.
+Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option to export strings as well. Note that hyphenation of longer strings is provided by the `babel` package using `USenglish` settings (and may conflict with your language settings).
 
 A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ A Stata command to automatically place a calculation into LaTeX -- no more hard 
 See the PDF and do file for more details.
 
 You can install the latest version of the *FORKED* command by executing the following code:
+
 `net install stattotex, from("https://raw.github.com/cg89x/stattotex/master/") replace`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # stattotex
+
+Forked versions of Ian Sappolnik's great `stattotex` command with added `string` option.
+
 A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
 
 See the PDF and do file for more details.
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # stattotex
-
-Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option to export strings as well. Note that hyphenation of longer strings is provided by the `babel` package using `USenglish` settings (and may conflict with your language settings).
-
+--------------------------------
 A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
 
 See the PDF and do file for more details.
+
+--------------------------------
+
+Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option to export strings as well. Note that hyphenation of longer strings is provided by the `babel` package using `USenglish` settings (and may conflict with your language settings).
+
+
 
 You can install the latest version of the **FORKED** command by executing the following code:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stattotex
 
-Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option.
+Forked versions of Ian Sappolnik's great [`stattotex`](https://github.com/isapollnik/stattotex)  command with added `string` option to export strings as well. Note that hyphenation of longer strings provided by the `babel` package using USenglish.
 
 A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # stattotex
---------------------------------
 A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
 
 See the PDF and do file for more details.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ A Stata command to automatically place a calculation into LaTeX -- no more hard 
 
 See the PDF and do file for more details.
 
-You can install the latest version of the *FORKED* command by executing the following code:
+You can install the latest version of the **FORKED** command by executing the following code:
 
 `net install stattotex, from("https://raw.github.com/cg89x/stattotex/master/") replace`

--- a/stata.toc
+++ b/stata.toc
@@ -1,3 +1,3 @@
-v 1.1
+v 1.2
 d stattotex: Automatically place calculation into LaTeX  
 p stattotex Automatic calculation into LaTeX 

--- a/stata.toc
+++ b/stata.toc
@@ -1,3 +1,3 @@
-v 1.3
+v 1.4
 d stattotex: Automatically place calculation into LaTeX  
 p stattotex Automatic calculation into LaTeX 

--- a/stata.toc
+++ b/stata.toc
@@ -1,4 +1,3 @@
 v 1.0
-d stattotex:
+d stattotex: Automatically place calculation into LaTeX  
 p stattotex Automatic calculation into LaTeX 
-* p links to a program package (to the mymean.pkg file) in the same folder.

--- a/stata.toc
+++ b/stata.toc
@@ -1,3 +1,3 @@
-v 1.0
+v 1.1
 d stattotex: Automatically place calculation into LaTeX  
 p stattotex Automatic calculation into LaTeX 

--- a/stata.toc
+++ b/stata.toc
@@ -1,3 +1,3 @@
-v 1.2
+v 1.3
 d stattotex: Automatically place calculation into LaTeX  
 p stattotex Automatic calculation into LaTeX 

--- a/stata.toc
+++ b/stata.toc
@@ -1,0 +1,4 @@
+v 1.0
+d stattotex:
+p stattotex Automatic calculation into LaTeX 
+* p links to a program package (to the mymean.pkg file) in the same folder.

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -2,7 +2,7 @@
 * @Author: Ian Sapollnik
 * @Date:   March 28, 2020
 * @Last Modified by:   Chris Kontz
-* @Last Modified time: 2020-07-27 11:28:33
+* @Last Modified time: 2020-07-27 11:30:33
 */
 
 * This program exports numbers in Stata for easy inclusion in LaTeX documents

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -10,7 +10,7 @@
 * Date: March 28, 2020
 program stattotex
 	
-	syntax using/, 
+	syntax using/, ///
 		STATistic(string) ///
 		name(string) /// 
 		[replace] ///
@@ -133,11 +133,13 @@ program stattotex
 			}
 		}
 		else{ // be mindful of existing files and just append the existing using command line / terminal tools
-			 if "`c(os)'" = "MacOSX" | "`c(os)'"=="UNIX" {
-				! echo "``statstringfortex''" >> "`using'"
+			 if "`c(os)'" == "MacOSX" | "`c(os)'"=="UNIX" {
+				! echo "\\\``statstringfortex''" >> "`using'"
+				! echo ""
 			 }
 			 else { // windows (not 100% sure that works too)
 				! echo "``statstringfortex''" >> "`using'"
+				! echo ""
 			 }
 
 		}
@@ -149,18 +151,10 @@ program stattotex
 									"% Preamble for hyphenated strings:" 	_n ///
 									"\usepackage[USenglish]{babel}"  		_n /// 
 								"%--------------------------------------%" 	_n
-	}
 
 	file write `newtexfile' _n "``statstringfortex''" _n
 	file close `newtexfile'
 	* Copy the temporary file over to its final location.
 	cp "``newtexfile''" "`using'"
+	}
 end
-
-
-if "`c(os)'"=="MacOSX" | "`c(os)'"=="UNIX" {
-	rsource using my_script.R, rpath("/usr/local/bin/R") roptions(`"--vanilla"')
-}
-else {  // windows
-	rsource using my_script.R, rpath(`"c:\r\R-3.5.1\bin\Rterm.exe"') roptions(`"--vanilla"')  // change version number, if necessary
-}

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -124,28 +124,7 @@ program define stattotex
 		* Write the new command into the file. 
 		file write `newtexfile' "%--------------------------------------%" _n ///
 						"% Preamble for hyphenated strings:" _n ///
-						"\usepackage{hyphenat, xstring, forloop}" _n ///
-						"\newsavebox\MyBreakChar% " _n ///
-						"\sbox\MyBreakChar{\hyp}% char to display the break after non char " _n ///
-						"\newsavebox\MySpaceBreakChar% " _n ///
-						"\sbox\MySpaceBreakChar{}% char to display the break after space " _n ///
-						"\makeatletter% " _n ///
-						"\newcommand*{\BreakableChar}[1][\MyBreakChar]{% " _n ///
-						"  \leavevmode% " _n ///
-						"  \prw@zbreak% " _n ///
-						"  \discretionary{\usebox#1}{}{}% " _n ///
-						"  \prw@zbreak% " _n ///
-						"}% " _n ///
-						"\newcounter{index}% " _n ///
-						"\newcommand{\AddBreakableChars}[1]{% " _n ///
-						"  \StrLen{#1 }[\stringLength]% " _n ///
-						"  \forloop[1]{index}{1}{\value{index}<\stringLength}{% " _n ///
-						"    \StrChar{#1}{\value{index}}[\currentLetter]% " _n ///
-						"    \IfStrEq{\currentLetter}{ } " _n ///
-						"        {\currentLetter\BreakableChar[\MySpaceBreakChar]}% " _n ///
-						"        {\currentLetter\BreakableChar[\MyBreakChar]}% " _n ///
-						"  }% " _n ///
-						"}% " _n ///
+						"\usepackage[USenglish]{babel}" ///
 						"%--------------------------------------%" _n
 	}
 

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -79,8 +79,7 @@ program define stattotex
 
 
 	if "`string'"!="" {
-		local `statstring' = subinstr("`statistic'", " ", "~", .)  // seqsplit does not allow for normal spaces, use ~ to simulate spaces
-		local `statstringfortex' = "\newcommand{\\`name'}{\seqsplit{" + "``statstring''" + "}}" + "`comment'"
+		local `statstringfortex' = "\newcommand{\\`name'}{\AddBreakableChars{" + "``statstring''" + "}}" + "`comment'"
 	}
 	* Create a new LaTeX file that will be the final output.
 	tempname newtexfile
@@ -117,10 +116,35 @@ program define stattotex
 	}
 	else {
 		disp as text "File `using' not found, will be created."
-		file write `newtexfile' "\usepackage{seqsplit}" _n	
+		* Write the new command into the file. 
+		file write `newtexfile' "%--------------------------------------%" _n ///
+						"% Preamble for hyphenated strings:" _n ///
+						"\usepackage{hyphenat, xstring, forloop}" _n ///
+						"\newsavebox\MyBreakChar% " _n ///
+						"\sbox\MyBreakChar{\hyp}% char to display the break after non char " _n ///
+						"\newsavebox\MySpaceBreakChar% " _n ///
+						"\sbox\MySpaceBreakChar{}% char to display the break after space " _n ///
+						"\makeatletter% " _n ///
+						"\newcommand*{\BreakableChar}[1][\MyBreakChar]{% " _n ///
+						"  \leavevmode% " _n ///
+						"  \prw@zbreak% " _n ///
+						"  \discretionary{\usebox#1}{}{}% " _n ///
+						"  \prw@zbreak% " _n ///
+						"}% " _n ///
+						"\newcounter{index}% " _n ///
+						"\newcommand{\AddBreakableChars}[1]{% " _n ///
+						"  \StrLen{#1 }[\stringLength]% " _n ///
+						"  \forloop[1]{index}{1}{\value{index}<\stringLength}{% " _n ///
+						"    \StrChar{#1}{\value{index}}[\currentLetter]% " _n ///
+						"    \IfStrEq{\currentLetter}{ } " _n ///
+						"        {\currentLetter\BreakableChar[\MySpaceBreakChar]}% " _n ///
+						"        {\currentLetter\BreakableChar[\MyBreakChar]}% " _n ///
+						"  }% " _n ///
+						"}% " _n ///
+						"%--------------------------------------%" _n
 	}
-	* Write the new command into the file. 
-	file write `newtexfile' "``statstringfortex''" _n
+
+	file write `newtexfile' _n "``statstringfortex''" _n
 	file close `newtexfile'
 	* Copy the temporary file over to its final location.
 	cp "``newtexfile''" "`using'"

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -124,7 +124,7 @@ program define stattotex
 		* Write the new command into the file. 
 		file write `newtexfile' "%--------------------------------------%" _n ///
 						"% Preamble for hyphenated strings:" _n ///
-						"\usepackage[USenglish]{babel}" ///
+						"\usepackage[USenglish]{babel}" /// _n
 						"%--------------------------------------%" _n
 	}
 

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -124,7 +124,7 @@ program define stattotex
 		* Write the new command into the file. 
 		file write `newtexfile' "%--------------------------------------%" _n ///
 						"% Preamble for hyphenated strings:" _n ///
-						"\usepackage[USenglish]{babel}" /// _n
+						"\usepackage[USenglish]{babel}"  _n /// 
 						"%--------------------------------------%" _n
 	}
 

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -1,8 +1,8 @@
 /*
 * @Author: Ian Sapollnik
 * @Date:   March 28, 2020
-* @Last Modified by:   Chris Kontz
-* @Last Modified time: 2020-07-27 19:50:07
+* @Last Modified by:   ChristianKontz
+* @Last Modified time: 2020-07-27 21:09:08
 */
 
 * This program exports numbers in Stata for easy inclusion in LaTeX documents
@@ -109,7 +109,7 @@ program stattotex
 			tempname oldtexfile
 			file open `oldtexfile' using "`using'", r
 			* Iterate over the lines of the file.
-			file read `oldtexfile' linecur
+			file read `oldtexfile' linecurstat
 			while r(eof)==0 {
 				if regexm(subinstr("`macval(linecur)'", "\newcommand{", "", .),"`name'") {
 					if ("`replace'"=="") {
@@ -133,13 +133,14 @@ program stattotex
 			}
 		}
 		else{ // be mindful of existing files and just append the existing using command line / terminal tools
-			 if "`c(os)'" == "MacOSX" | "`c(os)'"=="UNIX" {
-				! echo "\\\``statstringfortex''" >> "`using'"
-				! echo ""
+			 local `statstringfortex' = "\\\newcommand{\\\\`name'}{{" + "``statstring''" + "}}" + "`comment'"
+			 if "`c(os)'" == "MacOSX" | "`c(os)'"=="UNIX" | "`c(os)'"=="Unix" {
+				! printf "``statstringfortex''" >> "`using'"
+				! echo "" >> "`using'"
 			 }
 			 else { // windows (not 100% sure that works too)
-				! echo "``statstringfortex''" >> "`using'"
-				! echo ""
+				! printf "``statstringfortex''" >> "`using'"
+				! echo "" >> "`using'"
 			 }
 
 		}

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -1,4 +1,9 @@
-*! version 1.0  28mar2020
+/*
+* @Author: Ian Sapollnik
+* @Date:   March 28, 2020
+* @Last Modified by:   Chris Kontz
+* @Last Modified time: 2020-07-27 11:28:33
+*/
 
 * This program exports numbers in Stata for easy inclusion in LaTeX documents
 * Author: Ian Sapollnik

--- a/stattotex.ado
+++ b/stattotex.ado
@@ -84,7 +84,7 @@ program define stattotex
 
 
 	if "`string'"!="" {
-		local `statstringfortex' = "\newcommand{\\`name'}{\AddBreakableChars{" + "``statstring''" + "}}" + "`comment'"
+		local `statstringfortex' = "\newcommand{\\`name'}{{" + "``statstring''" + "}}" + "`comment'"
 	}
 	* Create a new LaTeX file that will be the final output.
 	tempname newtexfile

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -1,0 +1,7 @@
+v 1.0
+* v is followed by the version number
+d stattotex: generate latex links to avoid hardcoding numbers
+* d is followed by a description of the program
+f stattotex.ado
+f stattotex.sthlp
+* and lastly f denotes filenames that belong to your program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -1,4 +1,4 @@
-v 1.1
+v 1.2
 * v is followed by the version number
 d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -4,5 +4,5 @@ d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program
 f stattotex.ado
 f stattotex.sthlp
-f stattotex_SYMLIST.txt
+f stattotex_SYMLIST.ado
 * and lastly f denotes filenames that belong to your program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -4,5 +4,5 @@ d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program
 f stattotex.ado
 f stattotex.sthlp
-f stattotex_SYMLIST.ado
+F stattotex_SYMLIST.txt
 * and lastly f denotes filenames that belong to your program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -1,4 +1,4 @@
-v 1.3
+v 1.4
 * v is followed by the version number
 d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -4,4 +4,5 @@ d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program
 f stattotex.ado
 f stattotex.sthlp
+f stattotex_SYMLIST.txt
 * and lastly f denotes filenames that belong to your program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -1,4 +1,4 @@
-v 1.0
+v 1.1
 * v is followed by the version number
 d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program

--- a/stattotex.pkg
+++ b/stattotex.pkg
@@ -1,4 +1,4 @@
-v 1.2
+v 1.3
 * v is followed by the version number
 d stattotex: generate latex links to avoid hardcoding numbers
 * d is followed by a description of the program

--- a/stattotex.sthlp
+++ b/stattotex.sthlp
@@ -1,0 +1,10 @@
+{smcl}
+{* when we add ... in curly brackets at the end of a comment Stata will interpret}{...}
+{* the line as nonexistent, otherwise an empty line will show in the help file}{...}
+{cmd:help stattotex} {* cmd: highlights the following text as a command}
+{hline}{* draws a horizontal line, if followed by a number the line is not drawn over
+the whole page but only a certain amount of characters long}
+
+{title:Description}
+
+{cmd:stattotex} Please see https://github.com/isapollnik/stattotex for details.

--- a/stattotex.sthlp
+++ b/stattotex.sthlp
@@ -1,10 +1,8 @@
 {smcl}
-{* when we add ... in curly brackets at the end of a comment Stata will interpret}{...}
-{* the line as nonexistent, otherwise an empty line will show in the help file}{...}
-{cmd:help stattotex} {* cmd: highlights the following text as a command}
-{hline}{* draws a horizontal line, if followed by a number the line is not drawn over
-the whole page but only a certain amount of characters long}
+{cmd: stattotex
+{hline}{}
 
 {title:Description}
 
-{cmd:stattotex} Please see https://github.com/isapollnik/stattotex for details.
+{cmd:stattotex} A Stata command to automatically place a calculation into LaTeX -- no more hard coding!
+Please see https://github.com/isapollnik/stattotex for details.

--- a/stattotex.sthlp
+++ b/stattotex.sthlp
@@ -1,6 +1,6 @@
 {smcl}
-{cmd: stattotex
-{hline}{}
+{cmd: stattotex}
+{hline}
 
 {title:Description}
 


### PR DESCRIPTION
Hi Ian,

Great code! I have used a similar code for a while now but this one is way better. The only thing I am missing is an option to pass strings, e.g. a list of countries/entities you would analyze. 

I have added an option to parse strings with automatic line breaks and hyphenation in LaTeX for long strings (using the `babel` packages. This means, however, that the ` \include{numbersintext}` line has to be called before `\begin{document}` as we are loading a package. The preamble which calls the packages is created when the file is created.

I believe I respected all fail-safes you built in, i.e. you have to specify the option `STRing` for the program not to throw an error.

Best,

Chris